### PR TITLE
Add DeepL translate provider

### DIFF
--- a/src/translate/cli.ts
+++ b/src/translate/cli.ts
@@ -27,6 +27,8 @@ export const argv: Arguments = yargs(process.argv.slice(2))
         'lecto-rapid',
         'lingvanex-rapid',
         'nlp-rapid',
+        'deepl-free',
+        'deepl-pro'
       ],
       default: 'google-official',
     },

--- a/src/translate/payload.ts
+++ b/src/translate/payload.ts
@@ -23,3 +23,7 @@ export interface LingvanexTranslateResponse {
 export interface NLPTranslateResponse {
   data: { translated_text: { [x: string]: string } };
 }
+
+export interface DeepLTranslateResponse {
+  data: { translations:[{text: string, detected_source_language: string }]};
+}

--- a/src/translate/providers/deepl-free-api.ts
+++ b/src/translate/providers/deepl-free-api.ts
@@ -1,0 +1,49 @@
+import axios, { AxiosError, AxiosRequestConfig } from 'axios';
+import { decode, encode } from 'html-entities';
+import { argv } from '../cli';
+import { JSONObj, DeepLTranslateResponse } from '../payload';
+import { Translate } from '../translate';
+import { addCustomCert } from '../util';
+
+export class DeepLFreeAPI extends Translate {
+  private static readonly endpoint: string = 'api-free.deepl.com';
+  private static readonly axiosConfig: AxiosRequestConfig = {
+    headers: {
+      'Authorization': `DeepL-Auth-Key ${argv.key}`,
+      //'Content-type': 'application/x-www-form-urlencoded',
+    },
+    responseType: 'json',
+  };
+
+  constructor() {
+    super();
+    if (argv.certificatePath)
+    DeepLFreeAPI.axiosConfig.httpsAgent = addCustomCert(argv.certificatePath);
+  }
+
+  protected callTranslateAPI = (
+    valuesForTranslation: string[],
+    originalObject: JSONObj,
+    saveTo: string
+  ): void => {
+    axios
+      .post(
+        `https://${DeepLFreeAPI.endpoint}/v2/translate`,
+        {
+          text: [encode(valuesForTranslation.join(Translate.sentenceDelimiter))],
+          target_lang: argv.to,
+          source_lang: argv.from,
+          preserve_formatting: true,
+        },
+        DeepLFreeAPI.axiosConfig
+      )
+      .then((response) => {
+        const translations = (response as DeepLTranslateResponse).data.translations;
+        translations.map(t => {
+          //there is only one translation, so we could just take the first one
+          this.saveTranslation(decode(t.text), originalObject, saveTo);
+        });
+      })
+      .catch((error) => this.printAxiosError(error as AxiosError, saveTo));
+  };
+}

--- a/src/translate/providers/deepl-pro-api.ts
+++ b/src/translate/providers/deepl-pro-api.ts
@@ -1,0 +1,49 @@
+import axios, { AxiosError, AxiosRequestConfig } from 'axios';
+import { decode, encode } from 'html-entities';
+import { argv } from '../cli';
+import { JSONObj, DeepLTranslateResponse } from '../payload';
+import { Translate } from '../translate';
+import { addCustomCert } from '../util';
+
+export class DeepLProAPI extends Translate {
+  private static readonly endpoint: string = 'api.deepl.com';
+  private static readonly axiosConfig: AxiosRequestConfig = {
+    headers: {
+      'Authorization': `DeepL-Auth-Key ${argv.key}`,
+      //'Content-type': 'application/x-www-form-urlencoded',
+    },
+    responseType: 'json',
+  };
+
+  constructor() {
+    super();
+    if (argv.certificatePath)
+    DeepLProAPI.axiosConfig.httpsAgent = addCustomCert(argv.certificatePath);
+  }
+
+  protected callTranslateAPI = (
+    valuesForTranslation: string[],
+    originalObject: JSONObj,
+    saveTo: string
+  ): void => {
+    axios
+      .post(
+        `https://${DeepLProAPI.endpoint}/v2/translate`,
+        {
+          text: [encode(valuesForTranslation.join(Translate.sentenceDelimiter))],
+          target_lang: argv.to,
+          source_lang: argv.from,
+          preserve_formatting: true,
+        },
+        DeepLProAPI.axiosConfig
+      )
+      .then((response) => {
+        const translations = (response as DeepLTranslateResponse).data.translations;
+        translations.map(t => {
+          //there is only one translation, so we could just take the first one
+          this.saveTranslation(decode(t.text), originalObject, saveTo);
+        });
+      })
+      .catch((error) => this.printAxiosError(error as AxiosError, saveTo));
+  };
+}

--- a/src/translate/translate-supplier.ts
+++ b/src/translate/translate-supplier.ts
@@ -5,6 +5,8 @@ import { GoogleOfficialAPI } from './providers/google-official-api';
 import { LectoRapidAPI } from './providers/lecto-rapid-api';
 import { LingvanexRapidAPI } from './providers/lingvanex-rapid-api';
 import { NLPRapidAPI } from './providers/nlp-rapid-api';
+import { DeepLProAPI } from './providers/deepl-pro-api';
+import { DeepLFreeAPI } from './providers/deepl-free-api';
 import { Translate } from './translate';
 
 interface Providers {
@@ -15,6 +17,8 @@ interface Providers {
   'lecto-rapid': LectoRapidAPI;
   'lingvanex-rapid': LingvanexRapidAPI;
   'nlp-rapid': NLPRapidAPI;
+  'deepl-pro': DeepLProAPI;
+  'deepl-free': DeepLFreeAPI;
 }
 
 export class TranslateSupplier {
@@ -26,6 +30,8 @@ export class TranslateSupplier {
     'lecto-rapid': new LectoRapidAPI(),
     'lingvanex-rapid': new LingvanexRapidAPI(),
     'nlp-rapid': new NLPRapidAPI(),
+    'deepl-pro': new DeepLProAPI(),
+    'deepl-free': new DeepLFreeAPI(),
   };
 
   public static getProvider = (provider: string): Translate =>


### PR DESCRIPTION
Did not write any tests but tried it with:
```node dist/index.js -k "xxx" -d tests/i18n -f en -t sv -a deepl-free```

In my experience DeepL has very good translations. They also provide 500,000 characters per month free forever.

![image](https://github.com/while1618/i18n-auto-translation/assets/31588188/5b7ffa9d-9467-4aba-a139-442a401257e8)
