### PR TITLE
Change sentence Delimiter

### DIFF
--- a/src/translate/translate.ts
+++ b/src/translate/translate.ts
@@ -8,7 +8,7 @@ import { JSONObj } from './payload';
 import { replaceAll } from './util';
 
 export abstract class Translate {
-  public static readonly sentenceDelimiter: string = '\n{|}\n';
+  public static readonly sentenceDelimiter: string = '\n{~~~}\n';
   private static readonly skipWordRegex: RegExp =
     /({{([^{}]+)}}|<([^<>]+)>|<\/([^<>]+)>|\{([^{}]+)\})/g;
   private static readonly maxLinesPerRequest = 200;


### PR DESCRIPTION
Sentence Delimiter causes issues while using the package vue-i18n since '|' is used as a spliter between singular form and plural form